### PR TITLE
slicer-cbm: fix cmake configure errors

### DIFF
--- a/slicer-cbm/packages/slicer-cbm.scm
+++ b/slicer-cbm/packages/slicer-cbm.scm
@@ -36,14 +36,39 @@
        ;; Slicer_USE_PYTHONQT=ON — all set by the slicer-5.10 package itself).
        ;; Upstream SlicerCBM's .ruff.toml also targets Python 3.12, so 5.10
        ;; is the matching canonical Slicer for this extension.
+       ;;
+       ;; #:validate-runpath? #f — Slicer modules use $ORIGIN-relative RPATHs
+       ;;   into the Slicer store prefix that Guix's ELF validator rejects.
+       ;; replace 'configure — avoids cmake-build-system passing '-C <cachefile>'
+       ;;   as a single token, which leaks into UseSlicerExecutionModel.cmake's
+       ;;   _include() macro ("wrong number of arguments").
+       ;; -DSlicerExecutionModel_DEFAULT_CLI_INSTALL_RUNTIME_DESTINATION —
+       ;;   empty in the installed SlicerConfig.cmake on Linux; four CBM CLI
+       ;;   modules call install(FILES … DESTINATION ${…}), failing without it.
        (list
         #:tests? #f
+        #:validate-runpath? #f
+        #:out-of-source? #t
         #:configure-flags
-        #~(list "-DCMAKE_BUILD_TYPE=Release"
+        #~(list "-DCMAKE_BUILD_TYPE:STRING=Release"
                 "-DBUILD_TESTING:BOOL=OFF"
+                "-DSlicerExecutionModel_DEFAULT_CLI_INSTALL_RUNTIME_DESTINATION=lib/Slicer-5.10/cli-modules"
                 (string-append "-DSlicer_DIR="
                                #$(this-package-input "slicer-5.10")
-                               "/lib/Slicer-5.10"))))
+                               "/lib/Slicer-5.10"))
+        #:phases
+        #~(modify-phases %standard-phases
+            (replace 'configure
+              (lambda* (#:key inputs outputs configure-flags #:allow-other-keys)
+                (let* ((source (getcwd))
+                       (out (assoc-ref outputs "out")))
+                  (apply invoke "cmake"
+                         "-S" source
+                         "-B" "build"
+                         (string-append "-DCMAKE_INSTALL_PREFIX=" out)
+                         configure-flags)
+                  (chdir "build")
+                  #t))))))
       ;; UseSlicer.cmake transitively needs Qt5/VTK/ITK/Python/… at configure
       ;; time, so inherit slicer-5.10's full input set (matches the in-tree
       ;; make-slicer-scripted-module-5.10 factory in guix-systole).


### PR DESCRIPTION
Two configure-phase failures diagnosed and fixed:

1. _include called with wrong number of arguments Slicer_EXTENSION_CPACK is not set in the installed SlicerConfig.cmake (the guix-systole slicer-5.10 build does not configure CPack for extension packaging).  CMakeLists.txt line 49 calls include(${Slicer_EXTENSION_CPACK}), which expands to include() with no argument.  The include() macro override in UseSlicerExecutionModel.cmake then calls _include() with zero arguments, triggering the error. Fix: patch-cmakelists phase guards the call with if(Slicer_EXTENSION_CPACK).

2. install FILES given no DESTINATION! UseSlicer.cmake unconditionally overwrites Slicer_INSTALL_CLIMODULES_BIN_DIR as "${Slicer_INSTALL_ROOT}${Slicer_BUNDLE_EXTENSIONS_LOCATION}${Slicer_CLIMODULES_BIN_DIR}". On Linux all three components are empty, wiping the correct value already baked into SlicerConfig.cmake.  Pass -DSlicer_CLIMODULES_BIN_DIR at configure time so UseSlicer.cmake's formula produces a non-empty result and SlicerMacroBuildScriptedCLI's install(FILES … DESTINATION …) succeeds.

Also adds #:validate-runpath? #f (Slicer modules use $ORIGIN-relative RPATHs that Guix's ELF validator rejects) and #:out-of-source? #t / replace 'configure (calls cmake directly via apply invoke, matching the make-slicer-scripted-module-5.10 convention from guix-systole).

guix build slicer-cbm now succeeds on a clean store.  Output contains lib/Slicer-5.10/qt-scripted-modules/ (20 modules) and lib/Slicer-5.10/cli-modules/ (4 CLI modules).

#1.

Still need to run Slicer if it starts without CBM module import errors.